### PR TITLE
Clarify tax status language across governance, FAQ, and get-involved pages

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -13,6 +13,12 @@
     Regardless of legal status, we are a real community of people who gather regularly for worship,
     mutual support, and spiritual practice.
 
+- question: Are donations tax-deductible?
+  category: General
+  answer: >
+    We are incorporated in California and our IRS 501(c)(3) application is pending.
+    Donations are not currently tax-deductible.
+
 - question: What is a Blahaj?
   category: General
   answer: >

--- a/get-involved.html
+++ b/get-involved.html
@@ -228,6 +228,8 @@ hide_cta: true
   </div>
 </div>
 
+<p><strong>Tax status:</strong> The Blahaj Church is incorporated in California, our IRS 501(c)(3) recognition is pending, and donations are not currently tax-deductible.</p>
+
 <!-- Training Reimbursement -->
 <h2>Training Reimbursement</h2>
 

--- a/governance.html
+++ b/governance.html
@@ -108,10 +108,18 @@ permalink: /governance/
 
 <h2>Political Activity</h2>
 
-<p>The Blahaj Church does not participate in or intervene in any political campaign on behalf of or in opposition to any candidate for public office. No officer, minister, or representative shall endorse candidates, make political contributions on behalf of the church, or issue statements for or against any candidate while acting in their official capacity.</p>
+<p>The Blahaj Church does not participate in or intervene in any political campaign on behalf of or in opposition to any candidate for public office. No officer, minister, or representative may endorse candidates, make political contributions on behalf of the church, or issue statements for or against any candidate while acting in their official capacity.</p>
 
-<p>This prohibition is consistent with the requirements of Section 501(c)(3) of the Internal Revenue Code. The church may engage in issue-based advocacy and education consistent with its religious mission, provided such activities do not constitute a substantial part of its overall activities.</p>
+<p>This prohibition is a current internal policy and is also consistent with Section 501(c)(3) standards. If and when federal tax-exempt recognition is granted, this policy will continue as a legal requirement. The church may engage in issue-based advocacy and education consistent with its religious mission, provided such activities do not constitute a substantial part of its overall activities.</p>
+
+<h2>Tax Status</h2>
+
+<p>The Blahaj Church is incorporated in Sacramento County, California, as an active religious entity under state law.</p>
+
+<p>IRS 501(c)(3) recognition is currently pending and has not yet been approved.</p>
+
+<p>At this time, donations should not be treated as tax-deductible.</p>
 
 <h2>Dissolution</h2>
 
-<p>Upon dissolution, remaining assets after debt payment will be distributed to charitable, educational, or scientific organizations recognized under Section 501(c)(3) of the Internal Revenue Code. Potential recipients include the TGI Justice Project or other organizations aligned with our mission. The final decision will be made by the board at the time of dissolution.</p>
+<p>Upon dissolution, remaining assets after debt payment will be distributed in a manner consistent with our charitable and religious mission and applicable law at that time. If IRS 501(c)(3) recognition is in effect at dissolution, assets will be distributed to charitable, educational, or scientific organizations recognized under Section 501(c)(3). Potential recipients include the TGI Justice Project or other organizations aligned with our mission. The final decision will be made by the board at the time of dissolution.</p>


### PR DESCRIPTION
### Motivation
- Make a clear distinction between the church's current internal policies and the legal obligations that would apply if IRS 501(c)(3) recognition is later granted to avoid implying donations are deductible today.
- Provide a single-line, visitor-facing tax-status statement in governance, FAQ, and solicitation areas to keep public messaging consistent and reduce donor confusion.

### Description
- Revised Political Activity wording in `governance.html` to frame campaign non-intervention as a current internal policy that is also aligned with 501(c)(3) standards. (updated `governance.html`)
- Added a new **Tax Status** section to `governance.html` that states the entity is incorporated in Sacramento County, CA, that IRS 501(c)(3) recognition is pending, and that donations are not currently tax-deductible. (updated `governance.html`)
- Updated the Dissolution paragraph to reference distribution consistent with current mission and to conditionally apply 501(c)(3)-specific distribution rules if recognition is in effect at dissolution. (updated `governance.html`)
- Added a matching FAQ entry in `_data/faq.yml` titled "Are donations tax-deductible?" with the same pending/non-deductible messaging. (updated `_data/faq.yml`)
- Inserted the same concise tax-status line into `get-involved.html` near grants/support language to avoid implied deductibility in solicitation areas. (updated `get-involved.html`)

### Testing
- Ran `ruby -e "require 'yaml'; data=YAML.load_file('_data/faq.yml'); puts 'faq entries: ' + data.length.to_s"` to validate the FAQ YAML parsing, which completed successfully and reported the entries.
- Attempted `bundle exec jekyll build` to build the site, which failed in this environment because the `jekyll` executable is not installed via bundler.
- Served the site locally with `python -m http.server 4000` and captured full-page screenshots of the updated pages via Headless Playwright, producing artifacts for `governance` and `get-involved` pages (screenshots generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1391685d8832286680e34cbd6a87e)