### PR TITLE
Replace missing Font Awesome icons with local SVG alternatives

### DIFF
--- a/_includes/blahaj-explainer.html
+++ b/_includes/blahaj-explainer.html
@@ -1,4 +1,4 @@
 <aside class="blahaj-explainer" aria-label="What is a Blahaj?">
-  <h3><i class="fas fa-fish"></i> What is a Blahaj?</h3>
+  <h3><span class="cc-icon cc-icon-fish" aria-hidden="true"></span> What is a Blahaj?</h3>
   <p>"Blahaj" is Swedish for "blue shark" &mdash; and also the name of a beloved IKEA stuffed shark that became a symbol of comfort and solidarity in the trans community during the COVID-19 pandemic. We adopted the name as a sign of warmth, safety, and belonging. <a href="{{ '/blahaj-trans-icon/' | relative_url }}">Learn why Blåhaj became a trans icon.</a> <em>The Blahaj Church is not affiliated with or endorsed by IKEA.</em></p>
 </aside>

--- a/about.html
+++ b/about.html
@@ -293,7 +293,7 @@ permalink: /about/
 </div>
 
 <div class="teaching-group">
-  <h3 class="teaching-group-title"><i class="fas fa-hands"></i> Holy Practice</h3>
+  <h3 class="teaching-group-title"><span class="cc-icon cc-icon-hands" aria-hidden="true"></span> Holy Practice</h3>
   {% for teaching in site.data.teachings %}
     {% if teaching.group == "Holy Practice" %}
     <details class="teaching-card">

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -747,3 +747,28 @@ a:focus-visible {
 @media (max-width: 767px) {
   .text-md-right { text-align: left; }
 }
+
+/* Custom CC-friendly icon set (locally authored SVG masks) */
+.cc-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.cc-icon-book-open { -webkit-mask-image: url('/assets/img/icons/custom/book-open.svg'); mask-image: url('/assets/img/icons/custom/book-open.svg'); }
+.cc-icon-book-reader { -webkit-mask-image: url('/assets/img/icons/custom/book-reader.svg'); mask-image: url('/assets/img/icons/custom/book-reader.svg'); }
+.cc-icon-candle-holder { -webkit-mask-image: url('/assets/img/icons/custom/candle-holder.svg'); mask-image: url('/assets/img/icons/custom/candle-holder.svg'); }
+.cc-icon-door-open { -webkit-mask-image: url('/assets/img/icons/custom/door-open.svg'); mask-image: url('/assets/img/icons/custom/door-open.svg'); }
+.cc-icon-fish { -webkit-mask-image: url('/assets/img/icons/custom/fish.svg'); mask-image: url('/assets/img/icons/custom/fish.svg'); }
+.cc-icon-hands { -webkit-mask-image: url('/assets/img/icons/custom/hands.svg'); mask-image: url('/assets/img/icons/custom/hands.svg'); }
+.cc-icon-hands-helping { -webkit-mask-image: url('/assets/img/icons/custom/hands-helping.svg'); mask-image: url('/assets/img/icons/custom/hands-helping.svg'); }
+.cc-icon-pray { -webkit-mask-image: url('/assets/img/icons/custom/pray.svg'); mask-image: url('/assets/img/icons/custom/pray.svg'); }
+.cc-icon-spa { -webkit-mask-image: url('/assets/img/icons/custom/spa.svg'); mask-image: url('/assets/img/icons/custom/spa.svg'); }

--- a/assets/img/icons/custom/book-open.svg
+++ b/assets/img/icons/custom/book-open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 5.5A2.5 2.5 0 0 1 5.5 3H12v17H5.5A2.5 2.5 0 0 0 3 22z"/>
+  <path d="M21 5.5A2.5 2.5 0 0 0 18.5 3H12v17h6.5A2.5 2.5 0 0 1 21 22z"/>
+</svg>

--- a/assets/img/icons/custom/book-reader.svg
+++ b/assets/img/icons/custom/book-reader.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="5" r="2"/>
+  <path d="M8 9h8"/>
+  <path d="M4 10.5A2.5 2.5 0 0 1 6.5 8H12v12H6.5A2.5 2.5 0 0 0 4 22z"/>
+  <path d="M20 10.5A2.5 2.5 0 0 0 17.5 8H12v12h5.5A2.5 2.5 0 0 1 20 22z"/>
+</svg>

--- a/assets/img/icons/custom/candle-holder.svg
+++ b/assets/img/icons/custom/candle-holder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3c1.5 1.5 1.5 3.5 0 5-1.5-1.5-1.5-3.5 0-5z"/>
+  <rect x="10" y="8" width="4" height="7" rx="1"/>
+  <path d="M7 15h10"/>
+  <path d="M5 19h14"/>
+</svg>

--- a/assets/img/icons/custom/door-open.svg
+++ b/assets/img/icons/custom/door-open.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 3h10v18H6z"/>
+  <path d="M10 3v18"/>
+  <circle cx="12.5" cy="12" r="0.8" fill="black" stroke="none"/>
+  <path d="M16 12h4"/>
+</svg>

--- a/assets/img/icons/custom/fish.svg
+++ b/assets/img/icons/custom/fish.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12c3-4 9-6 14-4v8c-5 2-11 0-14-4z"/>
+  <path d="M17 10l4-3v10l-4-3"/>
+  <circle cx="8" cy="11" r="1" fill="black" stroke="none"/>
+</svg>

--- a/assets/img/icons/custom/hands-helping.svg
+++ b/assets/img/icons/custom/hands-helping.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 14h5l2 2h4l2-2h5"/>
+  <path d="M4 14V9h4l3 3"/>
+  <path d="M20 14V9h-4l-3 3"/>
+  <path d="M10 16l2 2 2-2"/>
+</svg>

--- a/assets/img/icons/custom/hands.svg
+++ b/assets/img/icons/custom/hands.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 13l4 4 4-4"/>
+  <path d="M21 13l-4 4-4-4"/>
+  <path d="M7 17h10"/>
+  <path d="M12 7v10"/>
+</svg>

--- a/assets/img/icons/custom/pray.svg
+++ b/assets/img/icons/custom/pray.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 4l2 4-2 12-4-3z"/>
+  <path d="M14 4l-2 4 2 12 4-3z"/>
+  <path d="M8 9h8"/>
+</svg>

--- a/assets/img/icons/custom/spa.svg
+++ b/assets/img/icons/custom/spa.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 18c0-3 2-5 5-6-1 2-1 4 0 6"/>
+  <path d="M17 18c0-3-2-5-5-6 1 2 1 4 0 6"/>
+  <path d="M12 6c2 1 3 3 3 5"/>
+  <path d="M12 6c-2 1-3 3-3 5"/>
+</svg>

--- a/church-goals.html
+++ b/church-goals.html
@@ -18,7 +18,7 @@ permalink: /church-goals/
   </div>
 
   <div class="goal-item">
-    <h3><i class="fas fa-hands"></i> Provide Spiritual Support</h3>
+    <h3><span class="cc-icon cc-icon-hands" aria-hidden="true"></span> Provide Spiritual Support</h3>
     <p>Many gender-diverse people face spiritual and emotional challenges related to their identities. We offer support, guidance, and a space for spiritual connection and fulfillment.</p>
   </div>
 
@@ -28,7 +28,7 @@ permalink: /church-goals/
   </div>
 
   <div class="goal-item">
-    <h3><i class="fas fa-book-open"></i> Promote Understanding</h3>
+    <h3><span class="cc-icon cc-icon-book-open" aria-hidden="true"></span> Promote Understanding</h3>
     <p>We promote education about gender diversity and work to combat misinformation and harmful stereotypes &ndash; both within and beyond our community.</p>
   </div>
 </div>

--- a/community.html
+++ b/community.html
@@ -346,19 +346,19 @@ permalink: /community/
 
 <div class="worship-timeline">
   <div class="timeline-step">
-    <div class="step-icon"><i class="fas fa-door-open"></i></div>
+    <div class="step-icon"><span class="cc-icon cc-icon-door-open" aria-hidden="true"></span></div>
     <h4>Gathering</h4>
     <p>We arrive, greet one another, and reconnect. This is fellowship time &ndash; catching up, sharing a meal, and settling in together.</p>
   </div>
 
   <div class="timeline-step">
-    <div class="step-icon"><i class="fas fa-book-open"></i></div>
+    <div class="step-icon"><span class="cc-icon cc-icon-book-open" aria-hidden="true"></span></div>
     <h4>Opening Reflection</h4>
     <p>A reading from a sacred or foundational text, or a reflection on the month's theme, opens the service and centers us as a community.</p>
   </div>
 
   <div class="timeline-step">
-    <div class="step-icon"><i class="fas fa-hands-helping"></i></div>
+    <div class="step-icon"><span class="cc-icon cc-icon-hands-helping" aria-hidden="true"></span></div>
     <h4>Community Check-In</h4>
     <p>We go around and share how we are doing. Are we safe? How is our health? Do we need gear or support? This is us caring for each other.</p>
   </div>
@@ -376,7 +376,7 @@ permalink: /community/
   </div>
 
   <div class="timeline-step">
-    <div class="step-icon"><i class="fas fa-pray"></i></div>
+    <div class="step-icon"><span class="cc-icon cc-icon-pray" aria-hidden="true"></span></div>
     <h4>Prayers &amp; Intentions</h4>
     <p>We hold space for prayers &ndash; for our community, for those facing hardship, for those we have lost, and for the wider world. Members may offer their own intentions.</p>
   </div>
@@ -423,7 +423,7 @@ permalink: /community/
   </div>
 
   <div class="activity-card">
-    <div class="activity-icon"><i class="fas fa-spa"></i></div>
+    <div class="activity-icon"><span class="cc-icon cc-icon-spa" aria-hidden="true"></span></div>
     <span class="card-tag">Periodic</span>
     <h3>Bath / Spa Days</h3>
     <p>Communal self-care in a safe, affirming environment. For many of us, spa and bathing spaces can feel hostile or unsafe. Our spa days reclaim that experience &ndash; massage, skincare, and the simple comfort of communal bathing without fear. Every body is sacred and deserving of care.</p>
@@ -447,7 +447,7 @@ permalink: /community/
 
 <div class="observance-cards">
   <div class="observance-card">
-    <div class="observance-icon"><i class="fas fa-candle-holder"></i></div>
+    <div class="observance-icon"><span class="cc-icon cc-icon-candle-holder" aria-hidden="true"></span></div>
     <span class="observance-date">November 20</span>
     <h3>Trans Day of Remembrance</h3>
     <p>We gather for a candlelight vigil and memorial service, honoring and remembering the lives lost to transphobic violence. The First Minister delivers a sermon, and members share reflections in a space of communal grieving and resolve.</p>

--- a/get-involved.html
+++ b/get-involved.html
@@ -210,7 +210,7 @@ hide_cta: true
   </div>
 
   <div class="involve-way-card">
-    <div class="way-icon"><i class="fas fa-hands-helping"></i></div>
+    <div class="way-icon"><span class="cc-icon cc-icon-hands-helping" aria-hidden="true"></span></div>
     <h4>Volunteer</h4>
     <p>Help organize events, maintain the website, or support community initiatives. Every contribution strengthens what we're building together.</p>
   </div>
@@ -222,7 +222,7 @@ hide_cta: true
   </div>
 
   <div class="involve-way-card">
-    <div class="way-icon"><i class="fas fa-book-reader"></i></div>
+    <div class="way-icon"><span class="cc-icon cc-icon-book-reader" aria-hidden="true"></span></div>
     <h4>Become a Minister</h4>
     <p>Learn about our ministerial training program and how you can serve the community. <a href="{{ '/ministerial-training' | relative_url }}">Explore ministerial training</a>.</p>
   </div>

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@ hide_cta: false
       <div class="community-preview">
         <ul class="gathering-list">
           <li class="gathering-item">
-            <div class="gathering-icon"><i class="fas fa-hands"></i></div>
+            <div class="gathering-icon"><span class="cc-icon cc-icon-hands" aria-hidden="true"></span></div>
             <div>
               <h4>Monthly Worship</h4>
               <p>In-person gatherings in the Bay Area with reflection, community check-in, sermon, and blessing.</p>
@@ -698,12 +698,12 @@ hide_cta: false
           <p>Join us monthly in the Bay Area or weekly online.</p>
         </a>
         <a href="{{ '/get-involved' | relative_url }}" class="involve-card">
-          <div class="involve-icon"><i class="fas fa-hands-helping"></i></div>
+          <div class="involve-icon"><span class="cc-icon cc-icon-hands-helping" aria-hidden="true"></span></div>
           <h4>Volunteer</h4>
           <p>Help build and shape this community.</p>
         </a>
         <a href="{{ '/resources' | relative_url }}" class="involve-card">
-          <div class="involve-icon"><i class="fas fa-book-open"></i></div>
+          <div class="involve-icon"><span class="cc-icon cc-icon-book-open" aria-hidden="true"></span></div>
           <h4>Explore Resources</h4>
           <p>Crisis support, legal aid, and community links.</p>
         </a>


### PR DESCRIPTION
### Motivation
- Several templates referenced Font Awesome glyphs that were not present in the shipped font, leaving visual placeholders broken on key pages. 
- Provide a CC-friendly, locally-hosted alternative so the site doesn't depend on missing/proprietary FA glyphs. 
- Preserve existing sizing/colour behavior so icons continue to match the site's typography and color scheme.

### Description
- Added a local SVG icon set under `assets/img/icons/custom/` for `book-open`, `book-reader`, `candle-holder`, `door-open`, `fish`, `hands`, `hands-helping`, `pray`, and `spa`.
- Implemented mask-based CSS rules in `assets/css/site.css` via a `.cc-icon` utility so SVGs render as colorable, scalable icons that inherit `currentColor`.
- Replaced usages of the missing FA icons with `<span class="cc-icon cc-icon-..." aria-hidden="true"></span>` across templates including `community.html`, `index.html`, `get-involved.html`, `church-goals.html`, `about.html`, and `_includes/blahaj-explainer.html`.
- Used a small scripted replacement to update templates and keep other FA usages untouched.

### Testing
- Ran `bundle install` successfully to ensure dependencies were available.
- Ran `bundle exec jekyll build` successfully to generate the site without errors.
- Executed an automated icon scan (Python script) that verifies used FA classes against `assets/css/fontawesome-all.min.css` and it reported no missing icons after the changes.
- Rendered pages and captured screenshots with Playwright; artifacts saved at `artifacts/community-icons.png` and `artifacts/index-icons.png` to visually confirm icons render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ea90cc2c8322b598a0e5de453195)