### PR TITLE
Add CC-friendly replacements for missing site icons

### DIFF
--- a/_includes/history-nav.html
+++ b/_includes/history-nav.html
@@ -4,7 +4,7 @@
 
     {% if page.permalink != '/history/sacred-lineage/' %}
     <a href="{{ '/history/sacred-lineage/' | relative_url }}" class="history-nav-card">
-      <div class="history-nav-icon"><i class="fas fa-scroll"></i></div>
+      <div class="history-nav-icon"><span class="cc-icon cc-icon-scroll" aria-hidden="true"></span></div>
       <h3>Sacred Lineage</h3>
       {% if page.permalink == '/history/blahaj-icon/' %}
       <p>The comfort the shark provides is part of a much older story &mdash; the ancient tradition of honoring gender diversity as sacred.</p>
@@ -32,7 +32,7 @@
 
     {% if page.permalink != '/history/founding/' %}
     <a href="{{ '/history/founding/' | relative_url }}" class="history-nav-card">
-      <div class="history-nav-icon"><i class="fas fa-church"></i></div>
+      <div class="history-nav-icon"><span class="cc-icon cc-icon-church" aria-hidden="true"></span></div>
       <h3>Our Founding</h3>
       {% if page.permalink == '/history/sacred-lineage/' %}
       <p>Learn how the Blahaj Church was founded to carry this sacred lineage forward into the modern world.</p>

--- a/about.html
+++ b/about.html
@@ -88,6 +88,8 @@ permalink: /about/
 
 {% include disclaimer-banner.html %}
 
+{% assign custom_icon_names = 'book-open|book-reader|candle-holder|church|cloud-rain|door-open|fish|fist-raised|hand-holding-heart|hands|hands-helping|hard-hat|pray|restroom|running|scroll|seedling|spa|water' | split: '|' %}
+
 <h2>Our Teachings</h2>
 
 <div class="teaching-group">
@@ -96,7 +98,7 @@ permalink: /about/
     {% if teaching.group == "The Sacred Body" %}
     <details class="teaching-card">
       <summary>
-        <span class="teaching-icon"><i class="fas fa-{{ teaching.icon }}"></i></span>
+        <span class="teaching-icon">{% if custom_icon_names contains teaching.icon %}<span class="cc-icon cc-icon-{{ teaching.icon }}" aria-hidden="true"></span>{% else %}<i class="fas fa-{{ teaching.icon }}"></i>{% endif %}</span>
         <span class="teaching-text">
           <span class="teaching-title">{{ teaching.title }}</span>
           <span class="teaching-summary">{{ teaching.summary }}</span>
@@ -116,7 +118,7 @@ permalink: /about/
     {% if teaching.group == "Holy Practice" %}
     <details class="teaching-card">
       <summary>
-        <span class="teaching-icon"><i class="fas fa-{{ teaching.icon }}"></i></span>
+        <span class="teaching-icon">{% if custom_icon_names contains teaching.icon %}<span class="cc-icon cc-icon-{{ teaching.icon }}" aria-hidden="true"></span>{% else %}<i class="fas fa-{{ teaching.icon }}"></i>{% endif %}</span>
         <span class="teaching-text">
           <span class="teaching-title">{{ teaching.title }}</span>
           <span class="teaching-summary">{{ teaching.summary }}</span>
@@ -136,7 +138,7 @@ permalink: /about/
     {% if teaching.group == "Love and Justice" %}
     <details class="teaching-card">
       <summary>
-        <span class="teaching-icon"><i class="fas fa-{{ teaching.icon }}"></i></span>
+        <span class="teaching-icon">{% if custom_icon_names contains teaching.icon %}<span class="cc-icon cc-icon-{{ teaching.icon }}" aria-hidden="true"></span>{% else %}<i class="fas fa-{{ teaching.icon }}"></i>{% endif %}</span>
         <span class="teaching-text">
           <span class="teaching-title">{{ teaching.title }}</span>
           <span class="teaching-summary">{{ teaching.summary }}</span>
@@ -156,7 +158,7 @@ permalink: /about/
     {% if teaching.group == "Health and Wholeness" %}
     <details class="teaching-card">
       <summary>
-        <span class="teaching-icon"><i class="fas fa-{{ teaching.icon }}"></i></span>
+        <span class="teaching-icon">{% if custom_icon_names contains teaching.icon %}<span class="cc-icon cc-icon-{{ teaching.icon }}" aria-hidden="true"></span>{% else %}<i class="fas fa-{{ teaching.icon }}"></i>{% endif %}</span>
         <span class="teaching-text">
           <span class="teaching-title">{{ teaching.title }}</span>
           <span class="teaching-summary">{{ teaching.summary }}</span>

--- a/acts-of-worship.html
+++ b/acts-of-worship.html
@@ -96,7 +96,7 @@ permalink: /acts-of-worship/
 
 <details class="teaching-card">
   <summary>
-    <span class="teaching-icon"><i class="fas fa-water"></i></span>
+    <span class="teaching-icon"><span class="cc-icon cc-icon-water" aria-hidden="true"></span></span>
     <span class="teaching-text">
       <span class="teaching-title">Sacred Bathing</span>
       <span class="teaching-summary">Communal bathing as a ritual of bodily affirmation and self-acceptance</span>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1007,6 +1007,16 @@ a:focus-visible {
 
 .cc-icon-book-open { -webkit-mask-image: url('/assets/img/icons/custom/book-open.svg'); mask-image: url('/assets/img/icons/custom/book-open.svg'); }
 .cc-icon-book-reader { -webkit-mask-image: url('/assets/img/icons/custom/book-reader.svg'); mask-image: url('/assets/img/icons/custom/book-reader.svg'); }
+.cc-icon-church { -webkit-mask-image: url('/assets/img/icons/custom/church.svg'); mask-image: url('/assets/img/icons/custom/church.svg'); }
+.cc-icon-cloud-rain { -webkit-mask-image: url('/assets/img/icons/custom/cloud-rain.svg'); mask-image: url('/assets/img/icons/custom/cloud-rain.svg'); }
+.cc-icon-fist-raised { -webkit-mask-image: url('/assets/img/icons/custom/fist-raised.svg'); mask-image: url('/assets/img/icons/custom/fist-raised.svg'); }
+.cc-icon-hand-holding-heart { -webkit-mask-image: url('/assets/img/icons/custom/hand-holding-heart.svg'); mask-image: url('/assets/img/icons/custom/hand-holding-heart.svg'); }
+.cc-icon-hard-hat { -webkit-mask-image: url('/assets/img/icons/custom/hard-hat.svg'); mask-image: url('/assets/img/icons/custom/hard-hat.svg'); }
+.cc-icon-restroom { -webkit-mask-image: url('/assets/img/icons/custom/restroom.svg'); mask-image: url('/assets/img/icons/custom/restroom.svg'); }
+.cc-icon-running { -webkit-mask-image: url('/assets/img/icons/custom/running.svg'); mask-image: url('/assets/img/icons/custom/running.svg'); }
+.cc-icon-scroll { -webkit-mask-image: url('/assets/img/icons/custom/scroll.svg'); mask-image: url('/assets/img/icons/custom/scroll.svg'); }
+.cc-icon-seedling { -webkit-mask-image: url('/assets/img/icons/custom/seedling.svg'); mask-image: url('/assets/img/icons/custom/seedling.svg'); }
+.cc-icon-water { -webkit-mask-image: url('/assets/img/icons/custom/water.svg'); mask-image: url('/assets/img/icons/custom/water.svg'); }
 .cc-icon-candle-holder { -webkit-mask-image: url('/assets/img/icons/custom/candle-holder.svg'); mask-image: url('/assets/img/icons/custom/candle-holder.svg'); }
 .cc-icon-door-open { -webkit-mask-image: url('/assets/img/icons/custom/door-open.svg'); mask-image: url('/assets/img/icons/custom/door-open.svg'); }
 .cc-icon-fish { -webkit-mask-image: url('/assets/img/icons/custom/fish.svg'); mask-image: url('/assets/img/icons/custom/fish.svg'); }

--- a/assets/img/icons/custom/church.svg
+++ b/assets/img/icons/custom/church.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3v4"/>
+  <path d="M10 5h4"/>
+  <path d="M5 21V10l7-4 7 4v11"/>
+  <path d="M9 21v-5h6v5"/>
+  <path d="M5 13h14"/>
+</svg>

--- a/assets/img/icons/custom/cloud-rain.svg
+++ b/assets/img/icons/custom/cloud-rain.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 16.5H6a4 4 0 1 1 .8-7.9A5.5 5.5 0 0 1 17.6 7 3.5 3.5 0 1 1 20 16.5z"/>
+  <path d="M8 18.5v2"/>
+  <path d="M12 18.5v2.5"/>
+  <path d="M16 18.5v2"/>
+</svg>

--- a/assets/img/icons/custom/fist-raised.svg
+++ b/assets/img/icons/custom/fist-raised.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 10V6a1 1 0 1 1 2 0v4"/>
+  <path d="M11 10V5a1 1 0 1 1 2 0v5"/>
+  <path d="M14 10V6a1 1 0 1 1 2 0v4"/>
+  <path d="M17 11V8a1 1 0 1 1 2 0v6"/>
+  <path d="M8 10a2 2 0 0 0-2 2v3a5 5 0 0 0 5 5h4a5 5 0 0 0 5-5v-1"/>
+</svg>

--- a/assets/img/icons/custom/hand-holding-heart.svg
+++ b/assets/img/icons/custom/hand-holding-heart.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 9s-2.2-1.8-3.7-.3A2.5 2.5 0 0 0 12 12a4.8 4.8 0 0 0 3.7-3.3C14.2 7.2 12 9 12 9z"/>
+  <path d="M3 15.5h6l2 2h5a2 2 0 0 0 0-4h-4"/>
+  <path d="M3 15.5v3h8.5"/>
+</svg>

--- a/assets/img/icons/custom/hard-hat.svg
+++ b/assets/img/icons/custom/hard-hat.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 14a8 8 0 0 1 16 0"/>
+  <path d="M2 14h20v4H2z"/>
+  <path d="M12 6v8"/>
+</svg>

--- a/assets/img/icons/custom/restroom.svg
+++ b/assets/img/icons/custom/restroom.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="8" cy="5" r="1.5"/>
+  <path d="M8 7v5"/>
+  <path d="M6 10h4"/>
+  <path d="M7 20l1-8 1 8"/>
+  <circle cx="16" cy="5" r="1.5"/>
+  <path d="M16 7v4"/>
+  <path d="M14 11h4l-1 4h-2z"/>
+</svg>

--- a/assets/img/icons/custom/running.svg
+++ b/assets/img/icons/custom/running.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="15" cy="4.5" r="1.5"/>
+  <path d="M12 10l3-2 2 1"/>
+  <path d="M10 13l3-3 2 2"/>
+  <path d="M13 12l-2 4"/>
+  <path d="M11 16l-4 3"/>
+  <path d="M15 14l4 2"/>
+</svg>

--- a/assets/img/icons/custom/scroll.svg
+++ b/assets/img/icons/custom/scroll.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 4h10a3 3 0 0 1 0 6H8a2 2 0 1 0 0 4h9"/>
+  <path d="M6 4a3 3 0 0 0 0 6"/>
+  <path d="M17 20a3 3 0 0 0 0-6"/>
+</svg>

--- a/assets/img/icons/custom/seedling.svg
+++ b/assets/img/icons/custom/seedling.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 21v-8"/>
+  <path d="M12 13c0-4 3-7 7-7 0 4-3 7-7 7z"/>
+  <path d="M12 16c0-3-2.5-5.5-5.5-5.5C6.5 13.5 9 16 12 16z"/>
+</svg>

--- a/assets/img/icons/custom/water.svg
+++ b/assets/img/icons/custom/water.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3s6 6 6 10a6 6 0 1 1-12 0C6 9 12 3 12 3z"/>
+  <path d="M9.5 13.5a2.5 2.5 0 0 0 5 0"/>
+</svg>

--- a/history/index.html
+++ b/history/index.html
@@ -10,7 +10,7 @@ description: The history of the Blahaj Church — from the ancient traditions of
 <div class="history-cards">
 
   <a href="{{ '/history/sacred-lineage/' | relative_url }}" class="history-card">
-    <div class="history-card-icon"><i class="fas fa-scroll"></i></div>
+    <div class="history-card-icon"><span class="cc-icon cc-icon-scroll" aria-hidden="true"></span></div>
     <h2>Sacred Lineage</h2>
     <p>The honoring of those who transcend gender boundaries is among the oldest spiritual traditions on earth. From the Two-Spirit healers of Indigenous North America to the Galli priests of ancient Rome, from the Talmud's six genders to the sacred power of Inanna &mdash; we stand in this ancient tradition.</p>
     <span class="history-card-link">Explore the sacred lineage <i class="fas fa-arrow-right"></i></span>
@@ -24,7 +24,7 @@ description: The history of the Blahaj Church — from the ancient traditions of
   </a>
 
   <a href="{{ '/history/founding/' | relative_url }}" class="history-card">
-    <div class="history-card-icon"><i class="fas fa-church"></i></div>
+    <div class="history-card-icon"><span class="cc-icon cc-icon-church" aria-hidden="true"></span></div>
     <h2>Our Founding</h2>
     <p>In 2023, from a period of burnout and spiritual crisis in San Francisco, a revelation emerged: that softness is sacred, that self-care is a spiritual discipline, and that the trans community deserved a permanent sanctuary built on these truths.</p>
     <span class="history-card-link">Read the founding story <i class="fas fa-arrow-right"></i></span>

--- a/index.html
+++ b/index.html
@@ -610,6 +610,8 @@ hide_cta: false
     </div>
   </div>
 
+{% assign custom_icon_names = 'book-open|book-reader|candle-holder|church|cloud-rain|door-open|fish|fist-raised|hand-holding-heart|hands|hands-helping|hard-hat|pray|restroom|running|scroll|seedling|spa|water' | split: '|' %}
+
   <!-- ===== WHAT WE BELIEVE PREVIEW ===== -->
   <section class="home-section">
     <div class="container">
@@ -621,7 +623,7 @@ hide_cta: false
           {% if featured contains teaching.title %}
           <div class="belief-card">
             <div class="belief-icon {% cycle 'pink-tint', 'blue-tint', 'pink-tint', 'blue-tint' %}">
-              <i class="fas fa-{{ teaching.icon }}"></i>
+              {% if custom_icon_names contains teaching.icon %}<span class="cc-icon cc-icon-{{ teaching.icon }}" aria-hidden="true"></span>{% else %}<i class="fas fa-{{ teaching.icon }}"></i>{% endif %}
             </div>
             <h3>{{ teaching.title }}</h3>
             <p>{{ teaching.summary }}</p>

--- a/way-of-the-shark/community-wisdom.html
+++ b/way-of-the-shark/community-wisdom.html
@@ -9,7 +9,7 @@ description: Lessons drawn from the lived experiences of the congregation — st
 
 <details class="teaching-card">
   <summary>
-    <span class="teaching-icon"><i class="fas fa-hard-hat"></i></span>
+    <span class="teaching-icon"><span class="cc-icon cc-icon-hard-hat" aria-hidden="true"></span></span>
     <span class="teaching-text">
       <span class="teaching-title">Good Helmets</span>
       <span class="teaching-summary">On the sacred duty of self-protection and the gear that stands between us and the ground</span>
@@ -25,7 +25,7 @@ description: Lessons drawn from the lived experiences of the congregation — st
 
 <details class="teaching-card">
   <summary>
-    <span class="teaching-icon"><i class="fas fa-seedling"></i></span>
+    <span class="teaching-icon"><span class="cc-icon cc-icon-seedling" aria-hidden="true"></span></span>
     <span class="teaching-text">
       <span class="teaching-title">Egg Cracking</span>
       <span class="teaching-summary">On patience, timing, and the sacred process of becoming who you are</span>

--- a/way-of-the-shark/index.html
+++ b/way-of-the-shark/index.html
@@ -26,7 +26,7 @@ description: A collection of parables, community wisdom, and stories of activism
   </a>
 
   <a href="{{ '/way-of-the-shark/acts-of-the-apostles/' | relative_url }}" class="history-card">
-    <div class="history-card-icon"><i class="fas fa-fist-raised"></i></div>
+    <div class="history-card-icon"><span class="cc-icon cc-icon-fist-raised" aria-hidden="true"></span></div>
     <h2>The Acts of the Apostles</h2>
     <p>Stories of activism, defiance, and solidarity from within and around our congregation. These accounts record the moments when members of our community stood up, spoke out, and moved the world &mdash; even by inches.</p>
     <span class="history-card-link">Read the acts <i class="fas fa-arrow-right"></i></span>


### PR DESCRIPTION
### Motivation
- The site referenced several Font Awesome icons that aren't available in the bundled font, producing missing glyphs; locally authored CC-friendly SVGs were added to ensure consistent, free-to-use icons that match the existing stroke style. 
- Teachings and a few content pages rely on icon names stored in data files, so template logic was needed to prefer local icons where Font Awesome glyphs are absent. 

### Description
- Added new SVG mask assets under `assets/img/icons/custom/` for the missing glyphs (`church`, `scroll`, `water`, `hard-hat`, `seedling`, `cloud-rain`, `fist-raised`, `hand-holding-heart`, `restroom`, `running`) and kept them in the same stroke style as existing custom icons. 
- Extended the `.cc-icon` mapping in `assets/css/site.css` to include `cc-icon-*` entries for each new icon so they can be referenced as mask images. 
- Updated teaching rendering in `about.html` and the homepage (`index.html`) to use a `custom_icon_names` list and conditionally render either a `<span class=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ee5f781083228ae369204d128741)